### PR TITLE
adding in lru_cache to lower running time of lambda

### DIFF
--- a/lambda_functions/transform_lambda.py
+++ b/lambda_functions/transform_lambda.py
@@ -3,6 +3,7 @@ import base64
 import boto3
 import logging
 import os
+from functools import lru_cache
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -119,6 +120,7 @@ def get_resource_tags_from_metric(
     return tags
 
 
+@lru_cache(maxsize=256)
 def get_tags_from_name(name, type, client) -> dict:
     tags = {}
     if type == "S3":
@@ -130,6 +132,7 @@ def get_tags_from_name(name, type, client) -> dict:
     return tags
 
 
+@lru_cache(maxsize=256)
 def get_tags_from_arn(arn, client) -> dict:
     tags = {}
     if ":domain/" in arn:


### PR DESCRIPTION
## Changes proposed in this pull request:
- By caching repeat results we save alot of time waiting on api calls
-
-

## Security considerations
None